### PR TITLE
(#2) Add target to update editorconfig after build

### DIFF
--- a/Chocolatey.BestPractices.csproj
+++ b/Chocolatey.BestPractices.csproj
@@ -13,8 +13,38 @@
   <ItemGroup>
     <None Include="Chocolatey.BestPractices.props" Pack="true" PackagePath="/build" />
     <None Include="Chocolatey.BestPractices.targets" Pack="true" PackagePath="/build" />
-    <None Include=".editorconfig" Pack="true" PackagePath="/build" />
+    <None Include="$(OutputPath).editorconfig" Pack="true" PackagePath="/build" />
     <None Include="readme.md" Pack="true" PackagePath="/" />
   </ItemGroup>
+
+  <UsingTask TaskName="ReplaceFileText" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <InputFilename ParameterType="System.String" Required="true" />
+      <OutputFilename ParameterType="System.String" Required="true" />
+      <MatchExpression ParameterType="System.String" Required="true" />
+      <ReplacementText ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+        <Using Namespace="System" />
+        <Using Namespace="System.IO" />
+        <Using Namespace="System.Text.RegularExpressions" />
+        <Code Type="Fragment" Language="cs">
+            <![CDATA[
+                File.WriteAllText(
+                    OutputFilename,
+                    Regex.Replace(File.ReadAllText(InputFilename), MatchExpression, ReplacementText)
+                    );
+            ]]>
+        </Code>
+    </Task>
+  </UsingTask>
+    
+  <Target Name="UpdateEditorConfig" AfterTargets="Build">
+    <ReplaceFileText
+      InputFilename="$(MSBuildProjectDirectory)\.editorconfig"
+      OutputFilename="$(OutputPath).editorconfig"
+      MatchExpression="root = true"
+      ReplacementText="root = false" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
## Description Of Changes
- Added a custom MSBuild target to update the `.editorconfig` file after build by replacing "root = true" with "root = false".
- Modified the project file to include the updated `.editorconfig` from the output path in the package.

## Motivation and Context
- To adjust the `.editorconfig` settings for downstream consumers by ensuring the correct configuration is packaged and distributed.

## Testing
- Verified that the `.editorconfig` file is correctly modified during the build.
- Confirmed the updated `.editorconfig` is included in the package output.

## Change Types Made
- [x] Bug fix (non-breaking change).
- [x] Feature / Enhancement (non-breaking change).

## Change Checklist

- [ ] Requires a change to the documentation.
- [ ] Documentation has been updated.
- [ ] Tests to cover my changes, have been added.
- [ ] All new and existing tests passed?
- [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
Fixes #2